### PR TITLE
Update configure-sharepoint-content-source.md

### DIFF
--- a/Viva/learning/configure-sharepoint-content-source.md
+++ b/Viva/learning/configure-sharepoint-content-source.md
@@ -65,7 +65,7 @@ The Learning Service uses the provided folder URLs to get metadata from all cont
 
 ## Configure SharePoint as a source
 
-You must be a Microsoft 365 global administrator, SharePoint administrator, or knowledge admin to perform these tasks.
+You must be a Microsoft 365 global administrator or knowledge admin to perform these tasks..
 
 To configure SharePoint as a learning content sources in for Viva Learning, follow these steps:
 


### PR DESCRIPTION
Within the section "## Configure SharePoint as a source 
It mentions "You must be a Microsoft 365 global administrator, SharePoint administrator, or knowledge admin to perform these tasks." However we see that a Sharepoint admin cannot access Viva Learning within services tab in Office365 admin center. Only Global admin or Knowledge admin can. 
This request is to remove Sharepoint admin, from the list and mention something in the lines of "You must be a Microsoft 365 global administrator, or knowledge admin to perform these tasks." I have updated the section above as a proposed change